### PR TITLE
fix(App): separate SearchPage

### DIFF
--- a/packages/client/src/App.js
+++ b/packages/client/src/App.js
@@ -4,7 +4,8 @@ import './App.css';
 import { LandingPage } from './containers/LandingPage/LandingPage.Container';
 import { PageNotFound } from './containers/PageNotFound/PageNotFound.Container';
 import { ProductView } from './containers/ProductView/ProductView.container';
-
+import ProductList from './components/ProductList/ProductList.component';
+// TODO: change ProductList into the page container CLASS22-40
 function App() {
   return (
     <div className="app">
@@ -12,7 +13,9 @@ function App() {
         <Routes>
           <Route path="/" element={<LandingPage />} />
           <Route path="*" element={<PageNotFound />} />
+          <Route path="/collections" element={<ProductList />} />
           <Route path="/products/:id" element={<ProductView />} />
+          {/* TODO: change ProductList into the page container CLASS22-40 */}
         </Routes>
       </Router>
     </div>

--- a/packages/client/src/containers/LandingPage/LandingPage.Container.js
+++ b/packages/client/src/containers/LandingPage/LandingPage.Container.js
@@ -2,15 +2,12 @@ import React from 'react';
 import './LandingPage.Style.css';
 import { Header } from '../../components/Header/Header.component';
 import Footer from '../../components/Footer/Footer';
-import ProductList from '../../components/ProductList/ProductList.component';
 
 export const LandingPage = () => {
   return (
     <div className="landing-page-container">
       <div className="content-wrap">
         <Header />
-        <ProductList />
-        <span>Landing Page</span>
       </div>
       <Footer />
     </div>


### PR DESCRIPTION
➡️  Landing team. Landing page + HomePage
` <Route path="/" element={<LandingPage />} />` 
We might need to drop the Landing page and just stay with Home, but that is for the future.


➡️  Search team
`<Route path="/collections" element={<ProductList />} />`
Needs to be replaced with the proper container ([jira](https://hackyourfuture-dk.atlassian.net/browse/CLASS22-40))


➡️  View team 
`<Route path="/products/:id" element={<ProductView />} />` 