### PR TITLE
fix(Modal): reset body overflow after closing

### DIFF
--- a/packages/client/src/components/Modal/Modal.component.js
+++ b/packages/client/src/components/Modal/Modal.component.js
@@ -9,6 +9,8 @@ const Modal = ({ toggle, open, title, children }) => {
     } else {
       document.body.style.overflow = '';
     }
+    // eslint-disable-next-line no-return-assign
+    return () => (document.body.style.overflow = '');
   }, [open]);
 
   if (!open) return null;

--- a/packages/client/src/components/Modal/Modal.component.js
+++ b/packages/client/src/components/Modal/Modal.component.js
@@ -1,10 +1,15 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import './modal.styles.css';
 
 const Modal = ({ toggle, open, title, children }) => {
   if (!open) return null;
   document.body.style.overflow = 'hidden';
+
+  const handleModalToggle = () => {
+    document.body.style.overflow = 'visible';
+    toggle();
+  };
 
   return (
     <div onClick={toggle} role="presentation" className="overlay">
@@ -19,7 +24,7 @@ const Modal = ({ toggle, open, title, children }) => {
           <h2>{title}</h2>
           <button
             type="button"
-            onClick={() => toggle()}
+            onClick={() => handleModalToggle()}
             className="modal-close-btn"
           >
             X

--- a/packages/client/src/components/Modal/Modal.component.js
+++ b/packages/client/src/components/Modal/Modal.component.js
@@ -1,15 +1,17 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import './modal.styles.css';
 
 const Modal = ({ toggle, open, title, children }) => {
-  if (!open) return null;
-  document.body.style.overflow = 'hidden';
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+  }, [open]);
 
-  const handleModalToggle = () => {
-    document.body.style.overflow = 'visible';
-    toggle();
-  };
+  if (!open) return null;
 
   return (
     <div onClick={toggle} role="presentation" className="overlay">
@@ -24,7 +26,7 @@ const Modal = ({ toggle, open, title, children }) => {
           <h2>{title}</h2>
           <button
             type="button"
-            onClick={() => handleModalToggle()}
+            onClick={() => toggle()}
             className="modal-close-btn"
           >
             X


### PR DESCRIPTION
# Description:

Added 
`    document.body.style.overflow = 'visible';
` to Modal toggle function. 






